### PR TITLE
Serverless support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # FROM python:3.6
 FROM public.ecr.aws/bitnami/python:3.6
-COPY --from=public.ecr.aws/m7b0o7h1/secret-env-vars-wrapper:latest-x86 /opt /opt
+COPY --from=public.ecr.aws/tinystacks/secret-env-vars-wrapper:latest-x86 /opt /opt
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.3.2-x86_64 /lambda-adapter /opt/extensions/lambda-adapter
 
 # Create app directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # FROM python:3.6
 FROM public.ecr.aws/bitnami/python:3.6
+COPY --from=public.ecr.aws/m7b0o7h1/secret-env-vars-wrapper:latest-x86 /opt /opt
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.3.2-x86_64 /lambda-adapter /opt/extensions/lambda-adapter
 
 # Create app directory
 WORKDIR /app
@@ -16,6 +18,6 @@ RUN python3 -m venv venv
 # Copy the whole folder inside the Image filesystem
 COPY . .
 
-EXPOSE 80
+EXPOSE 8000
 
-CMD gunicorn --bind 0.0.0.0:80 wsgi:app
+CMD /opt/tinystacks-secret-env-vars-wrapper gunicorn --bind 0.0.0.0:8000 wsgi:app

--- a/README.md
+++ b/README.md
@@ -151,12 +151,12 @@ PG_PORT=<postgres_port>
 
 to get all the items:
 ```
-curl --location --request GET '127.0.0.1:80/postgres-item' 
+curl --location --request GET '127.0.0.1:8000/postgres-item' 
 ```
 
 an example to create a new item:
 ```
-curl --location --request POST 'localhost:80/postgres-item' --header 'Content-Type: application/json' --data-raw '{"title":"theTitle","content":"theContent"}'
+curl --location --request POST 'localhost:8000/postgres-item' --header 'Content-Type: application/json' --data-raw '{"title":"theTitle","content":"theContent"}'
 ```
 
 ### Dockerfile
@@ -175,10 +175,10 @@ If you have Docker installed, you can build and try out the sample application l
 docker build -t tinystacks/flask-crud-app:latest .
 ```
 
-Once built, run the Docker command locally, mapping port 8080 on your host machine to port 80 on the container: 
+Once built, run the Docker command locally, mapping port 8080 on your host machine to port 8000 on the container: 
 
 ```
-docker run -p 8080:80 -d tinystacks/flask-crud-app:latest
+docker run -p 8080:8000 -d tinystacks/flask-crud-app:latest
 ```
 
 To test that the server is running, test its `/ping` endpoint from the command line. This time, you will change the port to 8080 to test that it's running from the running Docker container: 
@@ -246,10 +246,10 @@ If you already have an existing Flask application, you can use the core files in
 
 If your project is already Dockerized (i.e., it has its own Dockerfile), then simply copy over the `build.yml` and `release.yml` files into the root of your existing project. 
 
-If your project is not Dockerized, you will also need to copy over the Dockerfile included in this sample. If your application uses a different port than port 80, you will also need to update the `EXPOSE` line in the Dockerfile to use a different port:
+If your project is not Dockerized, you will also need to copy over the Dockerfile included in this sample. If your application uses a different port than port 8000, you will also need to update the `EXPOSE` line in the Dockerfile to use a different port:
 
 ```Dockerfile
-EXPOSE 80
+EXPOSE 8000
 ```
 
 ## Known Limitations

--- a/release.yml
+++ b/release.yml
@@ -10,4 +10,18 @@ phases:
     on-failure: CONTINUE
     commands:
       - region="${STAGE_REGION:-$AWS_REGION}" 
-      - if [ -z "$SERVICE_NAME" ] || [ "$SERVICE_NAME" == "placeholder" ]; then echo 'Service is not ready yet. Repository tagged correctly, exiting now'; else  aws ecs update-service --service $SERVICE_NAME --cluster $CLUSTER_ARN --region $region --force-new-deployment; fi
+      - |
+        if [ ! -z "$LAMBDA_FUNCTION_NAME" -a  "$LAMBDA_FUNCTION_NAME" != "placeholder" ];
+          then
+            aws lambda update-function-code --function-name "$LAMBDA_FUNCTION_NAME" --image-uri "$ECR_IMAGE_URL:$STAGE_NAME" --region $region
+            imageSha=$(docker images --no-trunc --quiet $ECR_IMAGE_URL:$PREVIOUS_STAGE_NAME);
+            aws lambda tag-resource --resource "$LAMBDA_FUNCTION_ARN" --tags "IMAGE_SHA=$imageSha"
+          else
+            echo 'Not a serverless stage'
+            if [ -z "$SERVICE_NAME" ] || [ "$SERVICE_NAME" == "placeholder" ];
+              then
+                echo 'Service is not ready yet. Repository tagged correctly, exiting now';
+              else
+                aws ecs update-service --service $SERVICE_NAME --cluster $CLUSTER_ARN --region $region --force-new-deployment;
+            fi
+        fi

--- a/wsgi.py
+++ b/wsgi.py
@@ -3,5 +3,5 @@ import os
 
 if __name__ == '__main__':
     stage = os.environ.get('STAGE', 'local')
-    the_port = 8000 if stage=='local' else 80
+    the_port = 8000
     app.run(host='0.0.0.0', port=the_port)


### PR DESCRIPTION
This PR includes the following changes in order to support serverless hosting on lambda:
1. Include two lambda extensions in Dockerfile
    - One for adapting to Lambda events
    - One for Secrets Manager support
2. Update release.yml
3. Change default port
    - port 80 cannot be used on Lambda (no privileged port can be used i.e. below 1024)